### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jameswoolfenden/pre-commit
-    rev: ba5c36a3150a4184f9ee362a5cf11611ee9ae185 # v0.1.52
+    rev: e022e4ac6ed682e95d1e813ee62d4fece371014b # v0.1.53
     hooks:
       - id: terraform-fmt
       - id: tf2docs

--- a/example/examplea/module.cassandra.tf
+++ b/example/examplea/module.cassandra.tf
@@ -12,7 +12,7 @@ module "cassandra" {
 
 
 module "myip" {
-  source = "jameswoolfenden/ip/http"
+  source = "git::https://github.com/jameswoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }
 
 locals {

--- a/example/exampleb/module.cassandra.tf
+++ b/example/exampleb/module.cassandra.tf
@@ -20,5 +20,5 @@ variable "ami" {
 
 
 module "myip" {
-  source = "jameswoolfenden/ip/http"
+  source = "git::https://github.com/jameswoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }

--- a/example/local/module.cassandra.tf
+++ b/example/local/module.cassandra.tf
@@ -11,5 +11,5 @@ module "cassandra" {
 
 
 module "myip" {
-  source = "jameswoolfenden/ip/http"
+  source = "git::https://github.com/jameswoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.